### PR TITLE
Clarified instructions for Linux users + updated docs' link

### DIFF
--- a/Guides/Getting Started.md
+++ b/Guides/Getting Started.md
@@ -2,7 +2,7 @@
 
 ## Preface
 
-If you are using Orion for tweak development, it is recommended that you use it with Theos. This guide assumes that you have Theos installed; if you haven't done that yet, please follow the [installation instructions](https://github.com/theos/theos/wiki/Installation) for Theos and then return to this guide.
+If you are using Orion for tweak development, it is recommended that you use it with Theos. This guide assumes that you have Theos installed; if you haven't done that yet, please follow the [installation instructions](https://theos.dev/docs/installation) for Theos and then return to this guide.
 
 If you wish to use Orion without Theos, please refer to the "[Using Orion Without Theos](using-orion-without-theos.html)" guide.
 
@@ -10,7 +10,7 @@ This guide will show you how to make a simple Orion tweak which… spices up tex
 
 To follow along, you will require the following things:
 
-- [Theos](https://github.com/theos/theos/wiki/Installation) on a machine running macOS, Windows 10 with WSL, or Linux.
+- [Theos](https://github.com/theos/theos/wiki/Installation) on a machine running macOS, Windows 10 with WSL, or Linux. If you're on a Linux environment, please make sure to install the Swift package from [here](https://www.swift.org/download/).
 - A jailbroken iOS device.
 - The target app (in this tutorial, VLC for iOS) installed on your iOS device.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.

- If you're on Linux/WSL and want to use Orion, after following the installation instructions if you try to compile a tweak the compilation will stop with something along the lines of `swift not found`. This is straightforward and tells you that you need Swift or it's not set in `$PATH`, but for beginners it may not be that obvious.

Does this close any currently open issues?

-

Any relevant logs, error output, etc?

-

Any other comments?

- It can also happen that when trying to compile an Objective-C project with bridged Swift code, it'll fail and throw Swift errors like `re-declaration of X class in file..`, which may not be the case and just confuse even more. This doesn't relate to Orion per se, but it can be fixed by downloading an official Swift toolchain compiled for Linux. Both of these scenarios have happened fairly recently and commented on in the Theos Discord server, so that's why the PR, which points were to get Swift from.

Where has this been tested?
---------------------------
**Operating System:** Kubuntu 21.04 x86_64, kernel version 5.11.0-49-generic

**Platform:**

**Target Platform:** iOS/iPadOS

**Toolchain Version:** CRKatri 5.3.2 Swift toolchain + Swift 5.5 toolchain from swift.org

**SDK Version:** 14.5