### PR TITLE
Support Swift 5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,13 +10,11 @@ enum Builder {
 }
 
 let swiftSyntaxVersion: Package.Dependency.Requirement = {
-    #if swift(>=5.6)
+    #if swift(>=5.5)
     #error("""
-    Orion does not support this version of Swift yet. \
-    Please check https://github.com/theos/Orion for progress updates.
+    Internal error: Swift Package Manager should be reading from
+    Package@swift-5.5.swift, not Package.swift.
     """)
-    #elseif swift(>=5.5)
-    return .exact("0.50500.0")
     #elseif swift(>=5.4)
     return .exact("0.50400.0")
     #elseif swift(>=5.3)

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -10,11 +10,13 @@ enum Builder {
 }
 
 let swiftSyntaxVersion: Package.Dependency.Requirement = {
-    #if swift(>=5.6)
+    #if swift(>=5.7)
     #error("""
     Orion does not support this version of Swift yet. \
     Please check https://github.com/theos/Orion for progress updates.
     """)
+    #elseif swift(>=5.6)
+    return .branch("release/5.6")
     #elseif swift(>=5.5)
     return .exact("0.50500.0")
     #elseif swift(>=5.4)
@@ -25,6 +27,14 @@ let swiftSyntaxVersion: Package.Dependency.Requirement = {
     return .exact("0.50200.0")
     #else
     #error("Orion does not support versions of Swift lower than 5.2.")
+    #endif
+}()
+
+let swiftSyntaxDep: String = {
+    #if swift(>=5.6)
+    return "SwiftSyntaxParser"
+    #else
+    return "SwiftSyntax"
     #endif
 }()
 
@@ -113,7 +123,9 @@ var package = Package(
     targets: [
         .target(
             name: "OrionProcessor",
-            dependencies: ["SwiftSyntax"]
+            dependencies: [
+                .product(name: swiftSyntaxDep, package: "SwiftSyntax")
+            ]
         ),
         .executableTarget(
             name: "OrionProcessorCLI",

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -16,7 +16,7 @@ let swiftSyntaxVersion: Package.Dependency.Requirement = {
     Please check https://github.com/theos/Orion for progress updates.
     """)
     #elseif swift(>=5.6)
-    return .branch("release/5.6")
+    return .exact("0.50600.1")
     #elseif swift(>=5.5)
     return .exact("0.50500.0")
     #elseif swift(>=5.4)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds Swift 5.6 support by updating swift-syntax accordingly.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
Nope

Any other comments?
-------------------
Nah

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** macOS 12.1 (21C52)

**Target Platform:** iOS

**Toolchain Version:** Xcode 13.3 (13E113)

**SDK Version:** iOS 15.4 (stock Xcode SDK)
