### PR TITLE
Support Swift 5.8

### DIFF
--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -10,11 +10,13 @@ enum Builder {
 }
 
 let swiftSyntax: Package.Dependency = {
-    #if swift(>=5.8)
+    #if swift(>=5.9)
     #error("""
     Orion does not support this version of Swift yet. \
     Please check https://github.com/theos/Orion for progress updates.
     """)
+    #elseif swift(>=5.8)
+    return .package(url: "https://github.com/apple/swift-syntax", exact: "508.0.0")
     #elseif swift(>=5.7)
     return .package(url: "https://github.com/apple/swift-syntax", exact: "0.50700.0")
     #elseif swift(>=5.6)
@@ -88,7 +90,7 @@ let rpathLinkerSettings: [LinkerSetting]? = {
 
 var package = Package(
     name: "Orion",
-    platforms: [.macOS("10.12")],
+    platforms: [.macOS("10.15")],
     products: [
         .library(
             name: "OrionProcessor",

--- a/Sources/OrionProcessor/OrionVisitor.swift
+++ b/Sources/OrionProcessor/OrionVisitor.swift
@@ -157,6 +157,7 @@ class OrionVisitor: SyntaxVisitor {
         self.diagnosticEngine = diagnosticEngine
         self.converter = sourceLocationConverter
         self.options = options
+        super.init(viewMode: .all)
     }
 
     private(set) var data = OrionData()
@@ -252,10 +253,10 @@ class OrionVisitor: SyntaxVisitor {
                 // we have to do this here: we can't simply prefix the func with "override" because
                 // it may have attributes, and we'll end up putting override before the attributes,
                 // whereas modifiers need to come after the attributes
-                SyntaxFactory.makeDeclModifier(
+                DeclModifierSyntax(
                     name: SyntaxFactory.makeIdentifier("override"),
-                    detailLeftParen: nil, detail: nil, detailRightParen: nil
-                ).withTrailingTrivia(.spaces(1))
+                    trailingTrivia: .spaces(1)
+                )
             )
             .withBody(SyntaxFactory.makeBlankCodeBlock())
             .withFuncKeyword(function.funcKeyword.withoutLeadingTrivia())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Handles Swift 5.8 and moves error message to Swift >= 5.9.
- Fix build errors possibly caused by XCode 14.3 changes? 

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** macOS 13.3

**Platform:** macOS

**Target Platform:** iphoneos

**Toolchain Version:** …

**SDK Version:** iPhoneOS16.4
