### PR TITLE
Support Swift 5.8 (supersedes #27)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,7 @@ disabled_rules:
   - large_tuple
   - identifier_name
   - type_name
+  - blanket_disable_command
 opt_in_rules:
   - closure_end_indentation
   - closure_spacing
@@ -61,7 +62,7 @@ custom_rules:
     message: "Use orionError instead of fatalError"
 force_try: warning
 force_cast: warning
-function_body_length: 80
+function_body_length: 100
 line_length: 135
 file_length: 450
 cyclomatic_complexity: 12

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -10,11 +10,13 @@ enum Builder {
 }
 
 let swiftSyntax: Package.Dependency = {
-    #if swift(>=5.8)
+    #if swift(>=5.9)
     #error("""
     Orion does not support this version of Swift yet. \
     Please check https://github.com/theos/Orion for progress updates.
     """)
+    #elseif swift(>=5.8)
+    return .package(url: "https://github.com/apple/swift-syntax", from: "508.0.0")
     #elseif swift(>=5.7)
     return .package(url: "https://github.com/apple/swift-syntax", exact: "0.50700.0")
     #elseif swift(>=5.6)
@@ -24,6 +26,14 @@ let swiftSyntax: Package.Dependency = {
     Internal error: Swift Package Manager should be reading from
     Package.swift, not Package@swift-5.6.swift.
     """)
+    #endif
+}()
+
+let macPlatform: SupportedPlatform = {
+    #if swift(>=5.8)
+    return .macOS("10.15")
+    #else
+    return .macOS("10.12")
     #endif
 }()
 
@@ -88,7 +98,7 @@ let rpathLinkerSettings: [LinkerSetting]? = {
 
 var package = Package(
     name: "Orion",
-    platforms: [.macOS("10.12")],
+    platforms: [macPlatform],
     products: [
         .library(
             name: "OrionProcessor",

--- a/Sources/Orion/Group.swift
+++ b/Sources/Orion/Group.swift
@@ -149,7 +149,6 @@ class GroupRegistry {
         let groupID = T.id
         // no point in using a read lock first since any non-failure case
         // will always require promoting to a write lock
-        // swiftlint:disable:next unneeded_parentheses_in_closure_argument
         let activation = groupsLock.withWriteLock { () -> (() -> Void)? in
             switch groups[groupID] {
             case nil:

--- a/Sources/OrionProcessor/OrionVisitor.swift
+++ b/Sources/OrionProcessor/OrionVisitor.swift
@@ -28,6 +28,19 @@ private extension SyntaxFactory {
 }
 #endif
 
+#if swift(>=5.8)
+extension SyntaxFactory {
+    static func makeDeclModifier(
+        name: TokenSyntax,
+        detailLeftParen: Any?,
+        detail: Any?,
+        detailRightParen: Any?
+    ) -> DeclModifierSyntax {
+        makeDeclModifier(name: name, detail: nil)
+    }
+}
+#endif
+
 private extension Diagnostic.Message {
     static func invalidDeclAccess(declKind: String) -> Diagnostic.Message {
         .init(.error, "A \(declKind) cannot be private, fileprivate, or final")
@@ -157,6 +170,9 @@ class OrionVisitor: SyntaxVisitor {
         self.diagnosticEngine = diagnosticEngine
         self.converter = sourceLocationConverter
         self.options = options
+        #if swift(>=5.8)
+        super.init(viewMode: .fixedUp)
+        #endif
     }
 
     private(set) var data = OrionData()


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds Swift 5.8 support while preserving compatibility with Swift <= 5.7. Changes based on #27 (thanks @ginsudev!)

Where has this been tested?
---------------------------
**Operating System:** macOS 13.1 (22C65)

**Platform:** macOS

**Target Platform:** macOS

**Toolchain Version:** Xcode 14.3

**SDK Version:** macOS 13.3
