### PR TITLE
Update GitHub Actions workflows to latest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,13 +3,40 @@ name: Build and Test
 on: [push, pull_request]
 
 jobs:
-  build-and-test:
+  test:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Build
-      run: swift build -v
     - name: Run tests
-      run: swift test -v
+      run: swift test
+
+  build:
+    strategy:
+      matrix:
+        xcode-version: [ "11.7", "12.4" ]
+        package-scheme: [ "", "rootless" ]
+    # match release workflow
+    runs-on: macos-11
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        path: orion
+    - name: Set Up Dependencies
+      run: |
+        brew install ldid make fakeroot
+        echo "THEOS=${GITHUB_WORKSPACE}/theos" >> "${GITHUB_ENV}"
+        echo "PATH=/usr/local/opt/make/libexec/gnubin:${PATH}" >> "${GITHUB_ENV}"
+    - name: Install Theos
+      uses: actions/checkout@v4
+      with:
+        repository: theos/theos
+        path: theos
+        submodules: recursive
+    - name: Build
+      run: |
+        cd orion
+        DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer \
+          make THEOS_PACKAGE_SCHEME="${{ matrix.package-scheme }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ jobs:
   build-and-test:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
   docs:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
         path: master-branch
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: docs
         path: docs-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         brew install ldid make fakeroot
         echo "THEOS=${GITHUB_WORKSPACE}/theos" >> "${GITHUB_ENV}"
         echo "PATH=/usr/local/opt/make/libexec/gnubin:${PATH}" >> "${GITHUB_ENV}"
-        echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+        echo "version=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
     - name: Install Theos
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     # TODO: Use a matrix instead
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
         path: orion
@@ -23,7 +23,7 @@ jobs:
         echo "PATH=/usr/local/opt/make/libexec/gnubin:${PATH}" >> "${GITHUB_ENV}"
         echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
     - name: Install Theos
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: theos/theos
         ref: 153c50c49dbbac0b47b87f9480d8d2c5d6d2ace1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: theos/theos
-        ref: 153c50c49dbbac0b47b87f9480d8d2c5d6d2ace1
         path: theos
         submodules: recursive
     - name: Build Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   release:
     # We need to use an old runner for Xcode 11.7
-    # TODO: Use a matrix instead
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   release:
+    # needed to be able to create a Release
+    permissions:
+      contents: write
     # We need to use an old runner for Xcode 11.7
     runs-on: macos-11
     steps:
@@ -36,24 +39,13 @@ jobs:
         DEVELOPER_DIR=/Applications/Xcode_11.7.app/Contents/Developer make clean package FINALPACKAGE=1
         cd packages
         zip -yr9 Orion_${{ steps.setup.outputs.version }}.zip *
-        cd ..
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ steps.setup.outputs.version }}
-        body: ''
-        draft: true
-        prerelease: false
-    - name: Upload Release
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/orion/packages/Orion_${{ steps.setup.outputs.version }}.zip
-        asset_name: Orion_${{ steps.setup.outputs.version }}.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create ${{ github.ref_name }} \
+        --verify-tag \
+        --draft \
+        --repo ${{ github.repository }} \
+        --title '${{ steps.setup.outputs.version }}' \
+        orion/packages/Orion_${{ steps.setup.outputs.version }}.zip

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -6,6 +6,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: GitHub Action for SwiftLint
       uses: norio-nomura/action-swiftlint@3.2.1


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Changes from commits:

- Update [`actions/checkout`](https://github.com/actions/checkout) to `v4`
- Always use latest [`theos/theos`](https://github.com/theos/theos) upstream
- Remove TODO to use a matrix for release workflow
  - A matrix would be more difficult to manage because all the artifacts would need to be uploaded and then downloaded to attach to the release
- Migrate to creating GitHub Releases using the official CLI
  - The [`actions/checkout`](https://github.com/actions/create-release) action is no longer maintained
  - Also migrate to workflow specific-tokens instead of an access token stored in Secrets
- Migrate to latest step output API
- Switch test workflow to use same steps as release workflow
  - Using the a build workflow closer to the release workflow means we're testing the code closer what will be deployed

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
- Tag deploy from this PR: https://github.com/leptos-null/orion/actions/runs/9142424939
- Successful test run: https://github.com/leptos-null/orion/actions/runs/9142279869
- Failing test run: https://github.com/leptos-null/orion/actions/runs/9142386514

Where has this been tested?
---------------------------
**Operating System:** macOS 11

**Platform:** macOS

**Target Platform:** iOS