### PR TITLE
Revert "Update for Xcode 14.3, use private module"

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,8 +10,6 @@ disabled_rules:
   - identifier_name
   - type_name
   - blanket_disable_command
-analyzer_rules:
-  - unused_import
 opt_in_rules:
   - closure_end_indentation
   - closure_spacing
@@ -29,6 +27,7 @@ opt_in_rules:
   - yoda_condition
   - nslocalizedstring_key
   - unused_setter_value
+  - unused_import
   - optional_enum_case_matching
   - prefer_self_type_over_type_of_self
   - contains_over_range_nil_comparison

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ before-package::
 
 internal-stage::
 	$(ECHO_NOTHING)mkdir -p $(THEOS_PACKAGE_DIR)$(ECHO_END)
-	$(ECHO_NOTHING)rm -rf $(SDK_DIR) $(DSYM_DIR) $(THEOS_STAGING_DIR)/Library/Frameworks/Orion.framework/{PrivateHeaders,Modules/{module.private.modulemap,Orion.swiftmodule/{*.private.swiftinterface,*.abi.json}}}$(ECHO_END)
+	$(ECHO_NOTHING)rm -rf $(SDK_DIR) $(DSYM_DIR) $(THEOS_STAGING_DIR)/Library/Frameworks/Orion.framework/PrivateHeaders$(ECHO_END)
 	$(ECHO_NOTHING)cp -a $(THEOS_STAGING_DIR)/Library/Frameworks/Orion.framework $(SDK_DIR)$(ECHO_END)
 ifeq ($(_THEOS_FINAL_PACKAGE),$(_THEOS_TRUE))
 	$(ECHO_NOTHING)cp -a $(THEOS_OBJ_DIR)/dSYMs/Orion.framework.dSYM $(DSYM_DIR)$(ECHO_END)
@@ -64,6 +64,7 @@ endif
 		ln -s Versions/Current/Orion.tbd $(SDK_DIR)/Orion.tbd; \
 		rm $(SDK_DIR)/Versions/Current/Orion; \
 	fi$(ECHO_END)
+	$(ECHO_NOTHING)sed -i '' -e '/ORION_PRIVATE_MODULE_BEGIN/,/ORION_PRIVATE_MODULE_END/d' $(SDK_DIR)/Modules/module.modulemap$(ECHO_END)
 	$(ECHO_NOTHING)rm $(SDK_DIR)/Orion $(SDK_DIR)/Modules/Orion.swiftmodule/*.swiftmodule$(ECHO_END)
 	$(ECHO_NOTHING)rm -rf $(THEOS_STAGING_DIR)/Library/Frameworks/Orion.doccarchive $(THEOS_STAGING_DIR)/Library/Frameworks/Orion.framework/{Headers,Modules}$(ECHO_END)
 

--- a/Orion.xcodeproj/project.pbxproj
+++ b/Orion.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -40,7 +40,6 @@
 		562BD3272638154C003C5A00 /* orion_objcrt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = orion_objcrt.h; sourceTree = "<group>"; };
 		562BD32A2638155A003C5A00 /* orion_objcrt.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = orion_objcrt.m; sourceTree = "<group>"; };
 		562BD32B2638155A003C5A00 /* orion_lifecycle.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = orion_lifecycle.c; sourceTree = "<group>"; };
-		562E6DF02A722D6A00ADB69E /* module.private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.private.modulemap; sourceTree = "<group>"; };
 		562FA0E225B7003E007A32FE /* Ivars+Weak.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ivars+Weak.swift"; sourceTree = "<group>"; };
 		565F484E25B1ED3400B75BA3 /* libsubstrate.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; path = libsubstrate.tbd; sourceTree = "<group>"; };
 		565F485725B1F0D000B75BA3 /* libsubstrate.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; path = libsubstrate.tbd; sourceTree = "<group>"; };
@@ -245,7 +244,6 @@
 			children = (
 				568974D8252BBFF4006F48E9 /* Info.plist */,
 				56D2CF9E2677AB6300F8DDBE /* module.modulemap */,
-				562E6DF02A722D6A00ADB69E /* module.private.modulemap */,
 				56DA77582677EECA007BDF43 /* Orion.h */,
 				56EEA36E2621DB9F00411C46 /* Orion-Target-iphonesimulator.h */,
 				56AF44C42621D8380041FBF6 /* Orion-Target-iphoneos.h */,
@@ -299,8 +297,7 @@
 		56897486252BB9C6006F48E9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					5689748E252BB9C6006F48E9 = {
 						CreatedOnToolsVersion = 12.0.1;
@@ -339,7 +336,6 @@
 /* Begin PBXShellScriptBuildPhase section */
 		5648210A25C9B7C300339957 /* Build CLI if Needed */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -361,7 +357,6 @@
 		};
 		5648211025C9BA6A00339957 /* Copy CLI if Needed */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -380,7 +375,6 @@
 		};
 		567AF4F32536817C0056182E /* Run SwiftLint If Present */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -399,7 +393,6 @@
 		};
 		56EEA3612621D90200411C46 /* Copy Target Header */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -590,7 +583,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -612,9 +604,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
 				MARKETING_VERSION = 1.0.1;
 				MODULEMAP_FILE = Orion/module.modulemap;
-				MODULEMAP_PRIVATE_FILE = Orion/module.private.modulemap;
-				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "-weak-lsubstrate";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.theos.orion;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -647,7 +636,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -669,9 +657,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
 				MARKETING_VERSION = 1.0.1;
 				MODULEMAP_FILE = Orion/module.modulemap;
-				MODULEMAP_PRIVATE_FILE = Orion/module.private.modulemap;
-				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "-weak-lsubstrate";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.theos.orion;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/Orion.xcodeproj/xcshareddata/xcschemes/Orion.xcscheme
+++ b/Orion.xcodeproj/xcshareddata/xcschemes/Orion.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Orion/Orion.h
+++ b/Orion/Orion.h
@@ -3,5 +3,5 @@
 FOUNDATION_EXPORT double OrionVersionNumber;
 FOUNDATION_EXPORT const unsigned char OrionVersionString[];
 
-#import <Orion/Orion-Target.h>
-#import <Orion/orion_public.h>
+#import "Orion-Target.h"
+#import "orion_public.h"

--- a/Orion/module.modulemap
+++ b/Orion/module.modulemap
@@ -4,3 +4,14 @@ framework module Orion {
   export *
   module * { export * }
 }
+// ORION_PRIVATE_MODULE_BEGIN
+
+// ideally we would declare this as Orion_Private in a
+// private modulemap but Swift seems to ignore private
+// modulemaps.
+explicit module Orion.Private {
+  header "orion_objcrt.h"
+  header "orion_lifecycle.h"
+}
+
+// ORION_PRIVATE_MODULE_END

--- a/Orion/module.private.modulemap
+++ b/Orion/module.private.modulemap
@@ -1,4 +1,0 @@
-framework module Orion_Private {
-  header "orion_objcrt.h"
-  header "orion_lifecycle.h"
-}

--- a/Sources/Orion/ClassHook+Deinit.swift
+++ b/Sources/Orion/ClassHook+Deinit.swift
@@ -2,7 +2,7 @@ import Foundation
 #if SWIFT_PACKAGE
 @_implementationOnly import OrionC
 #else
-@_implementationOnly import Orion_Private
+@_implementationOnly import Orion.Private
 #endif
 
 /// The action to perform after a `ClassHookProtocol.deinitializer()` is run.

--- a/Sources/Orion/ClassHook+Super.swift
+++ b/Sources/Orion/ClassHook+Super.swift
@@ -2,7 +2,7 @@ import Foundation
 #if SWIFT_PACKAGE
 @_implementationOnly import OrionC
 #else
-@_implementationOnly import Orion_Private
+@_implementationOnly import Orion.Private
 #endif
 
 // based on https://github.com/SSheldon/rust-objc/tree/95bce4e0d7fa99efebbd135a47cb7dec54710261/src/message/apple

--- a/Sources/OrionC/include/orion_lifecycle.h
+++ b/Sources/OrionC/include/orion_lifecycle.h
@@ -1,6 +1,8 @@
 #ifndef ORION_LIFECYCLE_H_
 #define ORION_LIFECYCLE_H_
 
+#include <orion_public.h>
+
 // this is only used in SPM mode but guarding it behind
 // a conditional confuses the compiler. Don't call it yourself.
 void _orion_init_c(void);

--- a/Sources/OrionC/orion_lifecycle.c
+++ b/Sources/OrionC/orion_lifecycle.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include "orion_lifecycle.h"
-#include "orion_public.h"
 
 #if SWIFT_PACKAGE
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This reverts commit 556ca6f544bb3a5db195a4ce9c5a94446946a49b

The changes made in the referenced commit do not seem to be compatible with { Xcode 11/ the associated Swift version } which is used for releases: https://github.com/theos/orion/blob/dd60a11d0fec56a52d5c6bf0850340e90748f16a/.github/workflows/release.yml#L38

Does this close any currently open issues?
------------------------------------------
Yes: #32 


Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
Added #34 to avoid issues in the future where "tests" passes for code that will not work on the "release" workflow.

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iOS

**Toolchain Version:** Xcode 11.7

**SDK Version:** 13
